### PR TITLE
fix(H5IMget_image_info): H5Sget_simple_extent_dims() does not exceed array…

### DIFF
--- a/hl/src/H5IM.c
+++ b/hl/src/H5IM.c
@@ -281,6 +281,8 @@ H5IMget_image_info(hid_t loc_id, const char *dset_name, hsize_t *width, hsize_t 
     if ((sid = H5Dget_space(did)) < 0)
         goto out;
 
+    if (H5Sget_simple_extent_dims(sid, NULL, NULL) > IMAGE24_RANK)
+        goto out;
     /* Get dimensions */
     if (H5Sget_simple_extent_dims(sid, dims, NULL) < 0)
         goto out;


### PR DESCRIPTION
… size

Malformed hdf5 files may provide more dimensions than the array dim[] is able to hold. Check number of elements first by calling H5Sget_simple_extent_dims() with NULL for both 'dims' and 'maxdims' arguments. This will cause the function to return only the number of dimensions.

This fixes CVE-2018-17439 / HDFFV-10589 / Bug #2226.

Signed-off-by: Egbert Eich <eich@suse.com>