### PR TITLE
fix(H5O_dtype_decode_helper): Parent of enum needs to have same size as en…

### DIFF
--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -470,6 +470,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed")
             if (H5O__dtype_decode_helper(ioflags, pp, dt->shared->parent) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDECODE, FAIL, "unable to decode parent datatype")
+            if (dt->shared->parent->shared->size != dt->shared->size)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADSIZE, FAIL, "ENUM datatype size does not match parent")
 
             /* Check if the parent of this enum has a version greater than the
              * enum itself. */


### PR DESCRIPTION
…um itself

The size of the enumeration values is determined by the size of the parent. Functions accessing the enumeration values use the size of the enumeration to determine the size of each element and how much data to copy. Thus the size of the enumeration and its parent need to match. Check here to avoid unpleasant surprises later.

This fixes CVE-2018-14031 / Bug #2236.

Signed-off-by: Egbert Eich <eich@suse.com>