### PR TITLE
fix(security): Make sure info block for external links has at least 3 bytes

### DIFF
--- a/src/H5Olink.c
+++ b/src/H5Olink.c
@@ -239,6 +239,8 @@ H5O__link_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
 
             /* A UD link.  Get the user-supplied data */
             UINT16DECODE(p, len)
+            if (lnk->type == H5L_TYPE_EXTERNAL && len < 3)
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "external link information lenght < 3")
             lnk->u.ud.size = len;
             if (len > 0) {
                 /* Make sure that length doesn't exceed buffer size, which could


### PR DESCRIPTION
According to the specification, the information block for external links contains 1 byte of version/flag information and two 0 terminated strings for the object linked to and the full path.
Although not very useful, the minimum string length for each (with terminating 0) would be one byte.
Checking this will help to avoid SEGVs triggered by bogus files.

This fixes CVE-2018-16438 / Bug #2233.

Signed-off-by: Egbert Eich <eich@suse.com>