### PR TITLE
build(autoconf): Make sure testsuite can handle multiple dependent scripts

### DIFF
--- a/config/conclude.am
+++ b/config/conclude.am
@@ -209,7 +209,14 @@ $(TEST_SCRIPT_CHKSH) $(TEST_SCRIPT_PARA_CHKSH) dummysh.chkexe_:
 	   chkname=`basename $(@:.chkexe_=.chkexe)`;\
 	   log=`basename $(@:.chkexe_=.chklog)`; \
 	   echo "============================"; \
-	   if [ $${chkname} -nt $$cmd ] && [ $${chkname} -nt $(SCRIPT_DEPEND) ]; then \
+	   newer=true; \
+	   for i in $${cmd} $(SCRIPT_DEPEND); do \
+              if [ $${chkname} -ot $$i ]; then \
+		 newer=false; \
+		 break; \
+	      fi; \
+           done; \
+	   if $${newer}; then \
 	      echo "No need to test $${tname} again."; \
 	   else \
 	      echo "============================" > $${log}; \


### PR DESCRIPTION
Commit afc54d75a19 to the test suite to eliminate a separate shell script did not take into account that there may be multiple dependent test scripts which resulted in the message:
`/bin/sh: line 7: [: too many arguments`.
when running the test suite.

Beware that this new version still makes use of non-posix GNU extensions to `test`.

Signed-off-by: Egbert Eich <eich@suse.com>