### PR TITLE
Add h5test_wrapper.h to isolate gcc and g++ to compile _Float16 files…

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set (CPP_HDRS
     ${HDF5_CPP_SRC_SOURCE_DIR}/H5PropList.h
     ${HDF5_CPP_SRC_SOURCE_DIR}/H5StrType.h
     ${HDF5_CPP_SRC_SOURCE_DIR}/H5VarLenType.h
+    ${HDF5_CPP_SRC_SOURCE_DIR}/H5Wrapper.h
 )
 
 if (BUILD_STATIC_LIBS)

--- a/c++/src/H5Wrapper.h
+++ b/c++/src/H5Wrapper.h
@@ -1,0 +1,21 @@
+// C++ informative line for the emacs editor: -*- C++ -*-
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef H5WRAPPER_H
+#define H5WRAPPER_H
+
+#if defined(__aarch64__) && defined(__GNUC__)
+#define _Float16 __fp16
+#endif
+
+#endif /* H5WRAPPER_H */

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -32,6 +32,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/h5cpputil.cpp
+++ b/c++/test/h5cpputil.cpp
@@ -26,6 +26,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -21,6 +21,7 @@
 #ifndef H5cpputil_H
 #define H5cpputil_H
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 
 using namespace H5;

--- a/c++/test/tarray.cpp
+++ b/c++/test/tarray.cpp
@@ -23,6 +23,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tattr.cpp
+++ b/c++/test/tattr.cpp
@@ -26,6 +26,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tcompound.cpp
+++ b/c++/test/tcompound.cpp
@@ -23,6 +23,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tdspl.cpp
+++ b/c++/test/tdspl.cpp
@@ -24,6 +24,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/testhdf5.cpp
+++ b/c++/test/testhdf5.cpp
@@ -45,6 +45,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tfile.cpp
+++ b/c++/test/tfile.cpp
@@ -27,6 +27,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tfilter.cpp
+++ b/c++/test/tfilter.cpp
@@ -23,6 +23,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/th5s.cpp
+++ b/c++/test/th5s.cpp
@@ -26,6 +26,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 #include "H5srcdir.h"  // srcdir querying header file

--- a/c++/test/titerate.cpp
+++ b/c++/test/titerate.cpp
@@ -23,6 +23,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tlinks.cpp
+++ b/c++/test/tlinks.cpp
@@ -24,6 +24,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tobject.cpp
+++ b/c++/test/tobject.cpp
@@ -21,6 +21,7 @@
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/trefer.cpp
+++ b/c++/test/trefer.cpp
@@ -24,6 +24,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/ttypes.cpp
+++ b/c++/test/ttypes.cpp
@@ -23,6 +23,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/c++/test/tvlstr.cpp
+++ b/c++/test/tvlstr.cpp
@@ -25,6 +25,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
+#include "H5Wrapper.h"
 #include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 

--- a/hl/c++/src/H5PacketTable.cpp
+++ b/hl/c++/src/H5PacketTable.cpp
@@ -18,6 +18,7 @@
  * February 2004
  */
 
+#include "H5Wrapper.h"
 /* High-level library internal header file */
 #include "H5HLprivate2.h"
 

--- a/hl/c++/src/Makefile.am
+++ b/hl/c++/src/Makefile.am
@@ -19,7 +19,7 @@ include $(top_srcdir)/config/commence.am
 include $(top_srcdir)/config/lt_vers.am
 
 # Include src directory
-AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/hl/src
+AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/c++/src -I$(top_srcdir)/hl/src
 
 # This is our main target
 lib_LTLIBRARIES=libhdf5_hl_cpp.la

--- a/hl/c++/test/ptableTest.cpp
+++ b/hl/c++/test/ptableTest.cpp
@@ -13,6 +13,7 @@
 /* ptableTest.cpp */
 
 #include <iostream>
+#include "H5Wrapper.h"
 #include "ptableTest.h"
 
 using namespace H5;


### PR DESCRIPTION
… on aarch64

_Float16 was supported in commit 330b80a266.

However there is build error report in aarch64, like this: ../../../src/H5private.h:605:23: error: '_Float16' does not name a type; did you mean '_Float64'?
  605 | __extension__ typedef _Float16 H5__Float16;
      |                       ^~~~~~~~
      |                       _Float64
make[2]: *** [Makefile:972: dsets.o] Error 1
make[1]: *** [Makefile:910: all-recursive] Error 1
make: *** [Makefile:739: all-recursive] Error 1

This commit adds a wrapper to isolate this difference